### PR TITLE
Correcting a syntactic error in ES6 class usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,11 +762,11 @@ Example:
 ```javascript
 class Buttons {}
 
-class Buttons.Red extends BlazeComponent {}
+Buttons.Red = class Red extends BlazeComponent {}
 
 Buttons.Red.register('Buttons.Red');
 
-class Buttons.Blue extends BlazeComponent {}
+Buttons.Blue = class Blue extends BlazeComponent {}
 
 Buttons.Blue.register('Buttons.Blue');
 ```


### PR DESCRIPTION
I don't think this bit in the readme file is valid ES6. If you want to use classes to create namespaces, it has to be done via assignment.

The preferred way of doing namespaces are through using the new module system. Unfortunately, Meteor hasn't integrated ES6 modules yet so we are stuck with this method for now.
